### PR TITLE
UIImage(QMUI)分类的四处小改进

### DIFF
--- a/QMUIKit/UIKitExtensions/UIImage+QMUI.m
+++ b/QMUIKit/UIKitExtensions/UIImage+QMUI.m
@@ -75,8 +75,10 @@ CGSizeFlatSpecificScale(CGSize size, float scale) {
         CGContextRef alphaContext = CGBitmapContextCreate(NULL, width, height, 8, 0, nil, kCGImageAlphaOnly);
         CGContextDrawImage(alphaContext, imageRect, self.CGImage);
         CGImageRef mask = CGBitmapContextCreateImage(alphaContext);
-        grayImage = [UIImage imageWithCGImage:CGImageCreateWithMask(imageRef, mask) scale:self.scale orientation:self.imageOrientation];
+		CGImageRef maskedGrayImageRef = CGImageCreateWithMask(imageRef, mask);
+        grayImage = [UIImage imageWithCGImage:maskedGrayImageRef scale:self.scale orientation:self.imageOrientation];
         CGImageRelease(mask);
+		CGImageRelease(maskedGrayImageRef);
         CGContextRelease(alphaContext);
         
         // 用 CGBitmapContextCreateImage 方式创建出来的图片，CGImageAlphaInfo 总是为 CGImageAlphaInfoNone，导致 qmui_opaque 与原图不一致，所以这里再做多一步
@@ -92,7 +94,7 @@ CGSizeFlatSpecificScale(CGSize size, float scale) {
 }
 
 - (UIImage *)qmui_imageWithAlpha:(CGFloat)alpha {
-    UIGraphicsBeginImageContextWithOptions(self.size, self.qmui_opaque, self.scale);
+    UIGraphicsBeginImageContextWithOptions(self.size, NO, self.scale);
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGContextInspectContext(context);
     CGRect drawingRect = CGRectMake(0, 0, self.size.width, self.size.height);
@@ -174,9 +176,11 @@ CGSizeFlatSpecificScale(CGSize size, float scale) {
     size = CGSizeFlatSpecificScale(size, scale);
     CGContextInspectSize(size);
     CGSize imageSize = self.size;
+	CGSize contextSize = CGSizeZero;
     CGRect drawingRect = CGRectZero;
     
     if (contentMode == UIViewContentModeScaleToFill) {
+		contextSize = size;
         drawingRect = CGRectMakeWithSize(size);
     } else {
         CGFloat horizontalRatio = size.width / imageSize.width;
@@ -190,9 +194,15 @@ CGSizeFlatSpecificScale(CGSize size, float scale) {
         }
         drawingRect.size.width = flatfSpecificScale(imageSize.width * ratio, scale);
         drawingRect.size.height = flatfSpecificScale(imageSize.height * ratio, scale);
+		if (contentMode == UIViewContentModeScaleAspectFill) {
+			contextSize = size;
+			drawingRect = CGRectSetXY(drawingRect, flatfSpecificScale((size.width - CGRectGetWidth(drawingRect)) / 2.0, scale), flatfSpecificScale((size.height - CGRectGetHeight(drawingRect)) / 2, scale));
+		} else {
+			contextSize = drawingRect.size;
+		}
     }
     
-    UIGraphicsBeginImageContextWithOptions(drawingRect.size, self.qmui_opaque, scale);
+    UIGraphicsBeginImageContextWithOptions(contextSize, self.qmui_opaque, scale);
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGContextInspectContext(context);
     [self drawInRect:drawingRect];
@@ -426,8 +436,9 @@ CGSizeFlatSpecificScale(CGSize size, float scale) {
     
     UIImage *resultImage = nil;
     color = color ? color : UIColorClear;
-    
-    UIGraphicsBeginImageContextWithOptions(size, NO, 0);
+
+	BOOL opaque = (cornerRadius == 0.0 && [color qmui_alpha] == 1.0);
+    UIGraphicsBeginImageContextWithOptions(size, opaque, 0);
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGContextSetFillColorWithColor(context, color.CGColor);
     

--- a/QMUIKit/UIKitExtensions/UIImage+QMUI.m
+++ b/QMUIKit/UIKitExtensions/UIImage+QMUI.m
@@ -176,11 +176,9 @@ CGSizeFlatSpecificScale(CGSize size, float scale) {
     size = CGSizeFlatSpecificScale(size, scale);
     CGContextInspectSize(size);
     CGSize imageSize = self.size;
-	CGSize contextSize = CGSizeZero;
     CGRect drawingRect = CGRectZero;
     
     if (contentMode == UIViewContentModeScaleToFill) {
-		contextSize = size;
         drawingRect = CGRectMakeWithSize(size);
     } else {
         CGFloat horizontalRatio = size.width / imageSize.width;
@@ -194,15 +192,9 @@ CGSizeFlatSpecificScale(CGSize size, float scale) {
         }
         drawingRect.size.width = flatfSpecificScale(imageSize.width * ratio, scale);
         drawingRect.size.height = flatfSpecificScale(imageSize.height * ratio, scale);
-		if (contentMode == UIViewContentModeScaleAspectFill) {
-			contextSize = size;
-			drawingRect = CGRectSetXY(drawingRect, flatfSpecificScale((size.width - CGRectGetWidth(drawingRect)) / 2.0, scale), flatfSpecificScale((size.height - CGRectGetHeight(drawingRect)) / 2, scale));
-		} else {
-			contextSize = drawingRect.size;
-		}
     }
     
-    UIGraphicsBeginImageContextWithOptions(contextSize, self.qmui_opaque, scale);
+    UIGraphicsBeginImageContextWithOptions(drawingRect.size, self.qmui_opaque, scale);
     CGContextRef context = UIGraphicsGetCurrentContext();
     CGContextInspectContext(context);
     [self drawInRect:drawingRect];


### PR DESCRIPTION
1.修复-[UIImage(QMUI) qmui_grayImage]方法中一个CGImageRef实例没有释放的问题。
2.修复-[UIImage(QMUI) qmui_imageWithAlpha:]方法在原图片不带alpha通道的情况下透明度调整不正确的问题。
3.改进+[UIImage(QMUI)
qmui_imageWithColor:size:cornerRadius:]方法，使之在圆角为0且颜色不透明的情况下能生成不带alpha通道的纯色图片。