### PR TITLE
新增：UIImage的拉伸方法

### DIFF
--- a/QMUIKit/UIKitExtensions/UIImage+QMUI.h
+++ b/QMUIKit/UIKitExtensions/UIImage+QMUI.h
@@ -52,6 +52,15 @@ typedef NS_OPTIONS(NSInteger, QMUIImageBorderPosition) {
 - (UIImage *)qmui_grayImage;
 
 /**
+ 将原图进行拉伸，但受保护区域不会被拉伸(类似于Android中9Patch)
+ 
+ @param image 原图
+ @param capInsets 受保护区域的范围
+ @return 拉伸后的图片
+ */
+- (UIImage *)qmui_resizableImageWithImage:(UIImage *)image protectedArea:(UIEdgeInsets)capInsets;
+
+/**
  *  设置一张图片的透明度
  *
  *  @param alpha 要用于渲染透明度

--- a/QMUIKit/UIKitExtensions/UIImage+QMUI.m
+++ b/QMUIKit/UIKitExtensions/UIImage+QMUI.m
@@ -93,6 +93,11 @@ CGSizeFlatSpecificScale(CGSize size, float scale) {
     return grayImage;
 }
 
+- (UIImage *)qmui_resizableImageWithImage:(UIImage *)image protectedArea:(UIEdgeInsets)capInsets {
+    UIImage *newImage = [image resizableImageWithCapInsets:capInsets resizingMode:UIImageResizingModeStretch];
+    return newImage;
+}
+
 - (UIImage *)qmui_imageWithAlpha:(CGFloat)alpha {
     UIGraphicsBeginImageContextWithOptions(self.size, NO, self.scale);
     CGContextRef context = UIGraphicsGetCurrentContext();


### PR DESCRIPTION
通过调用`resizableImageWithCapInsets`方法拉伸图片，虽然实现很简单，但也可以扩充在UIImage的扩展里，方便浏览。