### PR TITLE
解决当给 QMUIAlertController 添加 textField 时, 所引发的内存泄漏的问题.

### DIFF
--- a/QMUIKit/QMUIComponents/QMUIAlertController.m
+++ b/QMUIKit/QMUIComponents/QMUIAlertController.m
@@ -207,6 +207,8 @@ static QMUIAlertController *alertControllerAppearance;
 @property(nonatomic, assign) BOOL isNeedsHideAfterAlertShowed;
 @property(nonatomic, assign) BOOL isAnimatedForHideAfterAlertShowed;
 
+//
+@property(nonatomic, weak) QMUIAlertController *owner;
 @end
 
 @implementation QMUIAlertController {
@@ -492,6 +494,8 @@ static QMUIAlertController *alertControllerAppearance;
         self.title = title;
         self.message = message;
         self.preferredStyle = preferredStyle;
+        
+        self.owner = self;
         
         [self updateHeaderBackgrondColor];
         [self updateEffectBackgroundColor];
@@ -1103,6 +1107,7 @@ static QMUIAlertController *alertControllerAppearance;
         if (alertAction.handler) {
             alertAction.handler(alertAction);
             alertAction.handler = nil;
+            self.owner.alertActions = nil;
         }
     }];
 }

--- a/QMUIKit/QMUIComponents/QMUIAlertController.m
+++ b/QMUIKit/QMUIComponents/QMUIAlertController.m
@@ -1108,6 +1108,8 @@ static QMUIAlertController *alertControllerAppearance;
             alertAction.handler(alertAction);
             alertAction.handler = nil;
             self.owner.alertActions = nil;
+            self.owner.destructiveActions = nil;
+            self.owner.cancelAction = nil;
         }
     }];
 }

--- a/QMUIKit/QMUIComponents/QMUIAlertController.m
+++ b/QMUIKit/QMUIComponents/QMUIAlertController.m
@@ -207,7 +207,7 @@ static QMUIAlertController *alertControllerAppearance;
 @property(nonatomic, assign) BOOL isNeedsHideAfterAlertShowed;
 @property(nonatomic, assign) BOOL isAnimatedForHideAfterAlertShowed;
 
-//
+// 为了解决循环引用问题所引入的属性
 @property(nonatomic, weak) QMUIAlertController *owner;
 @end
 


### PR DESCRIPTION
当alertController添加了textfield， 如果在alertAction的block里使用的textfield，会出现内存泄露。