### PR TITLE
Fixed bug for QMUIMultipleDelegates

### DIFF
--- a/QMUIKit/QMUIComponents/QMUIMultipleDelegates/QMUIMultipleDelegates.m
+++ b/QMUIKit/QMUIComponents/QMUIMultipleDelegates/QMUIMultipleDelegates.m
@@ -58,7 +58,15 @@
             return result;
         }
     }
-    return nil;
+    // https://github.com/facebookarchive/AsyncDisplayKit/pull/1562
+    // Unfortunately, in order to get this object to work properly, the use of a method which creates an NSMethodSignature
+    // from a C string. -methodSignatureForSelector is called when a compiled definition for the selector cannot be found.
+    // This is the place where we have to create our own dud NSMethodSignature. This is necessary because if this method
+    // returns nil, a selector not found exception is raised. The string argument to -signatureWithObjCTypes: outlines
+    // the return type and arguments to the message. To return a dud NSMethodSignature, pretty much any signature will
+    // suffice. Since the -forwardInvocation call will do nothing if the delegate does not respond to the selector,
+    // the dud NSMethodSignature simply gets us around the exception.
+    return [NSMethodSignature signatureWithObjCTypes:"@^v^c"];
 }
 
 - (void)forwardInvocation:(NSInvocation *)anInvocation {


### PR DESCRIPTION
当 delegates 中能够响应的对象在执行 -methodSignatureForSelector: 方法时可能正好被释放掉，那么会返回 nil，而这会导致程序崩溃