### PR TITLE
修复 QMUIImagePreviewView 缺失 numberOfSectionsInCollectionView 引起Crash的问题

### DIFF
--- a/QMUIKit/QMUIComponents/QMUIImagePreviewView.m
+++ b/QMUIKit/QMUIComponents/QMUIImagePreviewView.m
@@ -133,6 +133,10 @@ static NSString * const kImageOrUnknownCellIdentifier = @"imageorunknown";
 
 #pragma mark - <UICollectionViewDataSource, UICollectionViewDelegateFlowLayout>
 
+- (NSInteger)numberOfSectionsInCollectionView:(UICollectionView *)collectionView {
+    return 1;
+}
+
 - (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
     if ([self.delegate respondsToSelector:@selector(numberOfImagesInImagePreviewView:)]) {
         return [self.delegate numberOfImagesInImagePreviewView:self];


### PR DESCRIPTION
QMUIImagePreviewView.m 文件的122行如下
```
QMUILog(@"QMUIImagePreviewView", @"dataSource 里的图片数量和当前显示出来的图片数量不匹配, collectionView.numberOfItems = %@, collectionViewDataSource.numberOfItems = %@, currentImageIndex = %@", @([self.collectionView numberOfItemsInSection:0]), @([self.collectionView.dataSource numberOfSectionsInCollectionView:self.collectionView]), @(_currentImageIndex));
```
默认情况下的self.collectionView.dataSource 是QMUIImagePreviewView实例， QMUIImagePreviewView 并没有实现 numberOfSectionsInCollectionView 方法会引发crash