### PR TITLE
QMUIEmptyView

### DIFF
--- a/QMUIKit/QMUIComponents/QMUIEmptyView.h
+++ b/QMUIKit/QMUIComponents/QMUIEmptyView.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+@class QMUIButton;
+
 @protocol QMUIEmptyViewLoadingViewProtocol <NSObject>
 
 @optional
@@ -26,7 +28,7 @@
 @property(nonatomic, strong, readonly) UIImageView *imageView;
 @property(nonatomic, strong, readonly) UILabel *textLabel;
 @property(nonatomic, strong, readonly) UILabel *detailTextLabel;
-@property(nonatomic, strong, readonly) UIButton *actionButton;
+@property(nonatomic, strong, readonly) QMUIButton *actionButton;
 
 // 可通过调整这些insets来控制间距
 @property(nonatomic, assign) UIEdgeInsets imageViewInsets UI_APPEARANCE_SELECTOR;   // 默认为(0, 0, 36, 0)

--- a/QMUIKit/QMUIComponents/QMUIEmptyView.m
+++ b/QMUIKit/QMUIComponents/QMUIEmptyView.m
@@ -49,7 +49,7 @@
     _actionButtonFont = appearance.actionButtonFont;
     _textLabelTextColor = appearance.textLabelTextColor;
     _detailTextLabelTextColor = appearance.detailTextLabelTextColor;
-    _actionButtonTitleColor = appearance.actionButtonTitleColor;
+    self.actionButtonTitleColor = appearance.actionButtonTitleColor;
     
     self.scrollView = [[UIScrollView alloc] init];
     if (@available(iOS 11, *)) {

--- a/QMUIKit/QMUIComponents/QMUIEmptyView.m
+++ b/QMUIKit/QMUIComponents/QMUIEmptyView.m
@@ -11,6 +11,7 @@
 #import "UIControl+QMUI.h"
 #import "NSParagraphStyle+QMUI.h"
 #import "UIView+QMUI.h"
+#import "QMUIButton/QMUIButton.h"
 
 @interface QMUIEmptyView ()
 
@@ -50,7 +51,7 @@
     _textLabelTextColor = appearance.textLabelTextColor;
     _detailTextLabelTextColor = appearance.detailTextLabelTextColor;
     self.actionButtonTitleColor = appearance.actionButtonTitleColor;
-    
+
     self.scrollView = [[UIScrollView alloc] init];
     if (@available(iOS 11, *)) {
         self.scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
@@ -82,7 +83,7 @@
     self.detailTextLabel.numberOfLines = 0;
     [self.contentView addSubview:self.detailTextLabel];
     
-    _actionButton = [[UIButton alloc] init];
+    _actionButton = [[QMUIButton alloc] init];
     self.actionButton.qmui_outsideEdge = UIEdgeInsetsMake(-20, -20, -20, -20);
     self.actionButton.qmui_automaticallyAdjustTouchHighlightedInScrollView = YES;
     [self.contentView addSubview:self.actionButton];


### PR DESCRIPTION
QMUIEmptyView appearance.actionButtonTitleColor 配置无效
将 QMUIEmptyView  自带的 button类型由UIButton改为 QMUIButton 以使用 QMUI 的一些特性