### PR TITLE
fix alert dismiss transform

### DIFF
--- a/QMUIKit/QMUIComponents/QMUIAlertController.m
+++ b/QMUIKit/QMUIComponents/QMUIAlertController.m
@@ -843,7 +843,7 @@ static QMUIAlertController *alertControllerAppearance;
                 }
             }];
         } else if (self.preferredStyle == QMUIAlertControllerStyleActionSheet) {
-            weakSelf.containerView.layer.transform = CATransform3DMakeTranslation(0, CGRectGetHeight(weakSelf.containerView.bounds), 0);
+            weakSelf.containerView.layer.transform = CATransform3DMakeTranslation(0, CGRectGetHeight(weakSelf.containerView.bounds) + self.view.qmui_safeAreaInsets.bottom, 0);
             [UIView animateWithDuration:0.25f delay:0 options:QMUIViewAnimationOptionsCurveOut animations:^{
                 weakSelf.maskView.alpha = 1;
                 weakSelf.containerView.layer.transform = CATransform3DIdentity;
@@ -869,7 +869,7 @@ static QMUIAlertController *alertControllerAppearance;
         } else if (self.preferredStyle == QMUIAlertControllerStyleActionSheet) {
             [UIView animateWithDuration:0.25f delay:0 options:QMUIViewAnimationOptionsCurveOut animations:^{
                 weakSelf.maskView.alpha = 0;
-                weakSelf.containerView.layer.transform = CATransform3DMakeTranslation(0, CGRectGetHeight(weakSelf.containerView.bounds), 0);
+                weakSelf.containerView.layer.transform = CATransform3DMakeTranslation(0, CGRectGetHeight(weakSelf.containerView.bounds) + self.view.qmui_safeAreaInsets.bottom, 0);
             } completion:^(BOOL finished) {
                 if (completion) {
                     completion(finished);
@@ -955,7 +955,7 @@ static QMUIAlertController *alertControllerAppearance;
         if (self.preferredStyle == QMUIAlertControllerStyleAlert) {
             weakSelf.containerView.alpha = 0;
         } else {
-            weakSelf.containerView.layer.transform = CATransform3DMakeTranslation(0, CGRectGetHeight(weakSelf.containerView.bounds), 0);
+            weakSelf.containerView.layer.transform = CATransform3DMakeTranslation(0, CGRectGetHeight(weakSelf.containerView.bounds) + self.view.qmui_safeAreaInsets.bottom, 0);
         }
         if ([weakSelf.delegate respondsToSelector:@selector(didHideAlertController:)]) {
             [weakSelf.delegate didHideAlertController:weakSelf];


### PR DESCRIPTION
**修复QMUIAlertControllerStyleActionSheet类型的模态视图dismiss的y轴位移距离问题**

> 原本问题：QMUIAlertControllerStyleActionSheet类型的模态视图dismiss时，由于消失距离没有算上safeArea的底部高度，导致在消失的时候，没有完全位移出手机底部，出现位移结束瞬间消失的顿挫感。

