### PR TITLE
[fix] scrollToRowAtIndexPath 中 indexPath 是否合法的判断

### DIFF
--- a/QMUIKit/UIKitExtensions/UITableView+QMUI.m
+++ b/QMUIKit/UIKitExtensions/UITableView+QMUI.m
@@ -262,9 +262,7 @@ const NSUInteger kFloatValuePrecision = 4;// 统一一个小数点运算精度
         isIndexPathLegal = NO;
     } else {
         NSInteger rows = [self numberOfRowsInSection:indexPath.section];
-        if (indexPath.row >= rows) {
-            isIndexPathLegal = NO;
-        }
+        isIndexPathLegal = rows > 0 ? indexPath.row < rows : indexPath.row == NSNotFound;
     }
     if (!isIndexPathLegal) {
         QMUILogWarn(@"UITableView (QMUI)", @"%@ - target indexPath : %@ ，不合法的indexPath。\n%@", self, indexPath, [NSThread callStackSymbols]);


### PR DESCRIPTION
未做对section为空row时的判断
<img width="494" alt="2018-11-14 4 36 54" src="https://user-images.githubusercontent.com/2424522/48470966-cf117400-e82d-11e8-812c-3574b7cc8a22.png">
