### PR TITLE
[fix] scrollToRowAtIndexPath 中 indexPath 是否合法的判断

### DIFF
--- a/QMUIKit/UIKitExtensions/UITableView+QMUI.m
+++ b/QMUIKit/UIKitExtensions/UITableView+QMUI.m
@@ -260,9 +260,9 @@ const NSUInteger kFloatValuePrecision = 4;// 统一一个小数点运算精度
     NSInteger numberOfSections = [self numberOfSections];
     if (indexPath.section >= numberOfSections) {
         isIndexPathLegal = NO;
-    } else {
+    } else if (indexPath.row != NSNotFound) {
         NSInteger rows = [self numberOfRowsInSection:indexPath.section];
-        isIndexPathLegal = rows > 0 ? indexPath.row < rows : indexPath.row == NSNotFound;
+        isIndexPathLegal = indexPath.row < rows;
     }
     if (!isIndexPathLegal) {
         QMUILogWarn(@"UITableView (QMUI)", @"%@ - target indexPath : %@ ，不合法的indexPath。\n%@", self, indexPath, [NSThread callStackSymbols]);


### PR DESCRIPTION
当 indexPath.row==NSNotFound 时，不管当前 tableview 是否有 rows 都能滚动。