### PR TITLE
修复iOS18.4 iPhone XS Max内存暴涨500MB问题Update QMUIConsoleViewController.m

### DIFF
--- a/QMUIKit/QMUIComponents/QMUIConsole/QMUIConsoleViewController.m
+++ b/QMUIKit/QMUIComponents/QMUIConsole/QMUIConsoleViewController.m
@@ -111,6 +111,8 @@
     self.textView.backgroundColor = [UIColor clearColor];
     self.textView.scrollsToTop = NO;
     self.textView.editable = NO;
+    self.textView.layoutManager.usesFontLeading = NO;
+    self.textView.layoutManager.allowsNonContiguousLayout = NO;
     self.textView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
     [self.contentView addSubview:self.textView];
 }


### PR DESCRIPTION
修复iOS18.4 iPhone XS Max内存暴涨500MB问题：
        self.textView.layoutManager.usesFontLeading = NO;
        self.textView.layoutManager.allowsNonContiguousLayout = NO;