### PR TITLE
QMUIAlertController Alert样式Actions 布局错误

### DIFF
--- a/QMUIKit/QMUIComponents/QMUIAlertController.h
+++ b/QMUIKit/QMUIComponents/QMUIAlertController.h
@@ -278,6 +278,13 @@ typedef NS_ENUM(NSInteger, QMUIAlertControllerStyle) {
  */
 @property(nonatomic, assign) BOOL orderActionsByAddedOrdered;
 
+/**
+ *  设置按钮的排序是否要严格按照用户添加的顺序来决定，默认为NO。
+ *
+ *  如果 strictOrderActionsByAddedOrdered 为 YES，则按钮的顺序将严格按照添加的顺序排列，不受其他因素影响。
+ */
+@property (nonatomic, assign) BOOL strictOrderActionsByAddedOrdered;
+
 /// dimmingView 是否响应点击，alert 默认为NO，sheet 默认为YES
 @property(nonatomic, assign) BOOL shouldRespondDimmingViewTouch;
 

--- a/QMUIKit/QMUIComponents/QMUIAlertController.m
+++ b/QMUIKit/QMUIComponents/QMUIAlertController.m
@@ -605,10 +605,10 @@ static NSUInteger alertControllerCount = 0;
             }
             if (!verticalLayout) {
                 // 对齐系统，先 add 的在右边，后 add 的在左边
-                QMUIAlertAction *leftAction = newOrderActions[1];
+                QMUIAlertAction *leftAction = self.strictOrderActionsByAddedOrdered ? newOrderActions[0] : newOrderActions[1];
                 leftAction.button.frame = CGRectMake(0, contentOriginY, CGRectGetWidth(self.buttonScrollView.bounds) / 2, self.alertButtonHeight);
                 leftAction.button.qmui_borderPosition = QMUIViewBorderPositionRight;
-                QMUIAlertAction *rightAction = newOrderActions[0];
+                QMUIAlertAction *rightAction = self.strictOrderActionsByAddedOrdered ? newOrderActions[1] : newOrderActions[0];
                 rightAction.button.frame = CGRectMake(CGRectGetMaxX(leftAction.button.frame), contentOriginY, CGRectGetWidth(self.buttonScrollView.bounds) / 2, self.alertButtonHeight);
                 if (shouldShowSeparatorAtTopOfButtonAtFirstLine) {
                     leftAction.button.qmui_borderPosition |= QMUIViewBorderPositionTop;
@@ -796,6 +796,10 @@ static NSUInteger alertControllerCount = 0;
 }
 
 - (NSArray<QMUIAlertAction *> *)orderedAlertActions:(NSArray<QMUIAlertAction *> *)actions {
+    if (self.strictOrderActionsByAddedOrdered) {
+        return actions;
+    }
+    
     NSMutableArray<QMUIAlertAction *> *newActions = [[NSMutableArray alloc] init];
     // 按照用户addAction的先后顺序来排序
     if (self.orderActionsByAddedOrdered) {


### PR DESCRIPTION
*   **期望 `QMUIAlertController` 能够完全按照添加顺序布局按钮。**

*   虽然提供了 `orderActionsByAddedOrdered` 属性，但仍然存在以下问题：
    *   取消按钮（`QMUIAlertActionStyleCancel`）始终会被放置在最后，这与期望的完全按添加顺序布局不符。
    *   在水平布局且只有两个按钮时，取消按钮又会被放置在左侧，导致布局行为不一致。

*   而`Alert` 按钮的文本样式可以通过全局的 `alertButtonAttributes`、`alertDestructiveButtonAttributes` 和 `alertCancelButtonAttributes` 进行配置。

*   但产品需求经常变化，有时要求取消按钮在左侧，有时又要求在右侧，缺乏灵活性。

*   **如果 `QMUIAlertController` 可以完全按照添加顺序布局按钮，开发者只需选择合适的 `QMUIAlertActionStyle` 并控制添加顺序，即可灵活满足各种布局需求，无需进行额外的全局样式调整。** 这样可以大大提高开发效率和布局的灵活性。