### PR TITLE
QMUIAlertController Alert样式Actions 布局错误

### DIFF
--- a/QMUIKit/QMUIComponents/QMUIAlertController.m
+++ b/QMUIKit/QMUIComponents/QMUIAlertController.m
@@ -604,11 +604,15 @@ static NSUInteger alertControllerCount = 0;
                 }
             }
             if (!verticalLayout) {
-                // 对齐系统，先 add 的在右边，后 add 的在左边
-                QMUIAlertAction *leftAction = newOrderActions[1];
+                /**
+                 * 对齐系统，先 add 的在右边，后 add 的在左边, 前提是存在 Cancel
+                 * newOrderActions 已经是将Cancel 重排在最后了
+                 */
+                BOOL needSwap = (newOrderActions.firstObject.style == QMUIAlertActionStyleCancel) || (newOrderActions.lastObject.style == QMUIAlertActionStyleCancel);
+                QMUIAlertAction *leftAction = needSwap ? newOrderActions[1] : newOrderActions[0];
                 leftAction.button.frame = CGRectMake(0, contentOriginY, CGRectGetWidth(self.buttonScrollView.bounds) / 2, self.alertButtonHeight);
                 leftAction.button.qmui_borderPosition = QMUIViewBorderPositionRight;
-                QMUIAlertAction *rightAction = newOrderActions[0];
+                QMUIAlertAction *rightAction = needSwap ? newOrderActions[0] : newOrderActions[1];
                 rightAction.button.frame = CGRectMake(CGRectGetMaxX(leftAction.button.frame), contentOriginY, CGRectGetWidth(self.buttonScrollView.bounds) / 2, self.alertButtonHeight);
                 if (shouldShowSeparatorAtTopOfButtonAtFirstLine) {
                     leftAction.button.qmui_borderPosition |= QMUIViewBorderPositionTop;


### PR DESCRIPTION
QMUIAlertController alert样式，当只有两个action，同时水平布局能放下时，会颠倒顺序，代码中注释着对齐系统行为，但是我测试了系统的UIAlertController 并不是这样呢？

https://github.com/Tencent/QMUI_iOS/blob/master/QMUIKit/QMUIComponents/QMUIAlertController.m#L607

<img width="1517" height="755" alt="Image" src="https://github.com/user-attachments/assets/9b43b801-0b19-46fc-b903-b47f0c06f24a" />

系统行为是存在 取消时才会交换

<img width="1520" height="748" alt="Image" src="https://github.com/user-attachments/assets/5ec90e85-4834-4cda-b3b1-6aa7c731fb54" />